### PR TITLE
Fix singular relationships by reference loading entire model

### DIFF
--- a/src/Support/Resource/AbstractEloquentResource.php
+++ b/src/Support/Resource/AbstractEloquentResource.php
@@ -165,7 +165,20 @@ abstract class AbstractEloquentResource extends AbstractJsonApiResource implemen
             }
 
         } else {
-            $ids = $relation->pluck($relatedModel->getQualifiedKeyName())->toArray();
+            // If the relation is singular, we just need the id so no need to query
+            // the entire model.
+            if ($relation instanceof Relations\BelongsTo) {
+                $foreignKeyName = $relation->getForeignKeyName();
+                $id = $this->model->getAttribute($foreignKeyName);
+
+                if ($id !== null) {
+                    $ids[] = $id;
+                } else {
+                    $ids = [];
+                }
+            } else {
+                $ids = $relation->pluck($relatedModel->getQualifiedKeyName())->toArray();
+            }
         }
 
         if ($singular) {


### PR DESCRIPTION
`$relation->pluck($relatedModel->getQualifiedKeyName())->toArray();` causes a query to be executed, only to get the id.

In some cases, like `hasOne` this is necessary, but in the case of `belongsTo` relations the value is already known as it is stored on the original record.